### PR TITLE
Remove backwards compatibility support for old FreeBSD

### DIFF
--- a/_pycapsicum.c
+++ b/_pycapsicum.c
@@ -32,11 +32,7 @@
 #include <fcntl.h>
 
 #include "Python.h"
-#if OSVERSION < 1020000
-#include "sys/capability.h"
-#else
 #include "sys/capsicum.h"
-#endif
 #include "sys/caprights.h"
 #include "structmember.h"
 


### PR DESCRIPTION
All supported versions of FreeBSD provide sys/capsicum.h, because
sys/capability.h conflicted with a draft POSIX.1e capability.h header
provided by other systems.  Remove the #ifdef case for older FreeBSD
because the test didn't work - for more information see FreeBSD
PR 228878 (https://bugs.freebsd.org/228878).